### PR TITLE
Only minor nitpicks and tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
-CC=gcc
-CFLAGS= -Wall -pedantic -ansi -g
-default: micro-lisp
-	./test.sh
+.PHONY: clean stats test
+
+CC ?= gcc
+CFLAGS += -Wall -pedantic -O2 -g
+
+all: clean micro-lisp stats test
 
 micro-lisp: micro-lisp.c
 	$(CC) $(CFLAGS) -o $@ $^
-	wc micro-lisp.c
+
+stats: micro-lisp.c
+	wc $^
+
+test: micro-lisp
+	./test.sh ./micro-lisp
 
 clean:
-	rm -v micro-lisp
+	@rm -fv micro-lisp

--- a/test.sh
+++ b/test.sh
@@ -1,75 +1,73 @@
 #!/usr/bin/env bash
 
-LISP=./micro-lisp
+LISP="${1:-./micro-flisp}"
 TOTAL=0
 SUCCESS=0
 
-function check-ok {
+check-ok() {
   echo "$1 -> $2"
-#  echo $1 | $LISP
   echo "$1" | $LISP | grep -q "^$2$"
   if [ $? -eq 0 ]; then
-    echo "Test OK"
+    echo Test OK
     SUCCESS=$((SUCCESS + 1))
   else
-    echo "Test FAIL"
+    echo Test FAIL
   fi
   TOTAL=$((TOTAL + 1))
 }
 
-function check-prog-ok {
+check-prog-ok() {
   echo "$1 -> $2"
-#  echo $1 | $LISP
   cat $1 | $LISP | grep -q "^$2$"
   if [ $? -eq 0 ]; then
-    echo "Test OK"
+    echo Test OK
     SUCCESS=$((SUCCESS + 1))
   else
-    echo "Test FAIL"
+    echo Test FAIL
   fi
   TOTAL=$((TOTAL + 1))
 }
 
-function check-repl-ok {
+check-repl-ok() {
   echo "$1 -> $2"
   echo $1 | cat repl0.lisp - | ./micro-lisp | grep -q "^$2$"
   if [ $? -eq 0 ]; then
-    echo "Test OK"
+    echo Test OK
     SUCCESS=$((SUCCESS + 1))
   else
-    echo "Test FAIL"
+    echo Test FAIL
   fi
   TOTAL=$((TOTAL + 1))
 }
 
-check-ok "(car (quote (1 2 3 4)))" "1"
-check-ok "(cdr (quote (1 2 3 4)))" "(2 3 4)"
-check-ok "(cons (quote 1) (cons (quote 2) null))" "(1 2)"
-check-ok "((lambda (x) (cons x (cons (quote 1) null))) (quote 7))" "(7 1)"
-check-ok "(pair? (quote (1 2 3)))" "(quote t)"
-check-ok "(eq? (quote hello) (quote hello))" "(quote t)"
-check-ok "(eq? (quote hello) (quote world))" "null"
-check-ok "(pair? (cons (quote hello) (quote world)))" "(quote t)"
-check-ok "(pair? (quote hello))" "null"
-check-ok "((1 (x) (cons x (quote 1))) 2)" "null"
-check-ok "1" "null"
-check-ok "((lambda (x) (write x)) (quote hello))" "hello"
-check-ok "(write (quote (cons (quote 1) (quote 2))))" "(cons (quote 1) (quote 2))"
-check-ok "(cons (quote 1) (cons (quote 2) (cons (quote 3) (cons (quote 4) null))))" "(1 2 3 4)"
-check-ok "(quote (1 2 3 4))" "(1 2 3 4)"
-check-ok "(cons (quote 1) (cons (quote 2) null))" "(1 2)"
-check-ok "(write (cons (quote (hello world)) null))" "((hello world))"
-check-ok "((lambda (x y) (cons y (cons x null))) (quote 67) (quote 89))" "(89 67)"
+check-ok '(car (quote (1 2 3 4)))' '1'
+check-ok '(cdr (quote (1 2 3 4)))' '(2 3 4)'
+check-ok '(cons (quote 1) (cons (quote 2) null))' '(1 2)'
+check-ok '((lambda (x) (cons x (cons (quote 1) null))) (quote 7))' '(7 1)'
+check-ok '(pair? (quote (1 2 3)))' '(quote t)'
+check-ok '(eq? (quote hello) (quote hello))' '(quote t)'
+check-ok '(eq? (quote hello) (quote world))' 'null'
+check-ok '(pair? (cons (quote hello) (quote world)))' '(quote t)'
+check-ok '(pair? (quote hello))' 'null'
+check-ok '((1 (x) (cons x (quote 1))) 2)' 'null'
+check-ok '1' 'null'
+check-ok '((lambda (x) (write x)) (quote hello))' 'hello'
+check-ok '(write (quote (cons (quote 1) (quote 2))))' '(cons (quote 1) (quote 2))'
+check-ok '(cons (quote 1) (cons (quote 2) (cons (quote 3) (cons (quote 4) null))))' '(1 2 3 4)'
+check-ok '(quote (1 2 3 4))' '(1 2 3 4)'
+check-ok '(cons (quote 1) (cons (quote 2) null))' '(1 2)'
+check-ok '(write (cons (quote (hello world)) null))' '((hello world))'
+check-ok '((lambda (x y) (cons y (cons x null))) (quote 67) (quote 89))' '(89 67)'
 
-check-prog-ok assoc.lisp "lisp"
-check-prog-ok apply.lisp "(fn 1 2 3 4)"
-check-prog-ok apply2.lisp "(fn (1 2 3 4))"
-check-prog-ok reverse.lisp "(9 8 7 6 5 4 3 2 1)"
+check-prog-ok assoc.lisp 'lisp'
+check-prog-ok apply.lisp '(fn 1 2 3 4)'
+check-prog-ok apply2.lisp '(fn (1 2 3 4))'
+check-prog-ok reverse.lisp '(9 8 7 6 5 4 3 2 1)'
 
-check-repl-ok "hello" "carl"
-check-repl-ok "(quote (write hello))" "(write hello)"
-check-repl-ok "(write (cons (quote hello) (cons (quote world) null)))" "(hello world)"
-check-repl-ok "(apply write (cons (quote hello) (cons (quote world) null)))" "(hello world)"
+check-repl-ok 'hello' 'carl'
+check-repl-ok '(quote (write hello))' '(write hello)'
+check-repl-ok '(write (cons (quote hello) (cons (quote world) null)))' '(hello world)'
+check-repl-ok '(apply write (cons (quote hello) (cons (quote world) null)))' '(hello world)'
 
 echo "Passed $SUCCESS of $TOTAL"
 


### PR DESCRIPTION
Only formatting changes, nitpicks and minor tweaks:

* Let `./test.sh` take the lisp executable as the first argument.
* Let `$CC` be specified when running `make` by the user but with `gcc` as the default (`?=`).
* Add `.PHONY` for make targets that does not produce anything.
* Strings in bash with no variable expansion can be single quoted.
* `all` instead of `default` in the Makefile (just a bit more common).
* `rm -f` is conventional for the `clean` target.
* Let `CFLAGS` add options to the end of the string with `+=`.
* `name() {` is shorter than `function name {`, and more compatible with
the syntax of other shells than bash, should that ever be a wish.
* `wc $^` is shorter.